### PR TITLE
[ORG] RU-AXAV: bpo-16580: [doc] Add examples to int.to_bytes and int.from_bytes (GH-…

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -529,6 +529,18 @@ class`. In addition, it provides a few more methods:
     given, an :exc:`OverflowError` is raised. The default value for *signed*
     is ``False``.
 
+    Equivalent to::
+
+        def to_bytes(n, length, byteorder, signed=False):
+            if byteorder == 'little':
+                order = range(length)
+            elif byteorder == 'big':
+                order = reversed(range(length))
+            else:
+                raise ValueError("byteorder must be either 'little' or 'big'")
+
+            return bytes((n >> i*8) & 0xff for i in order)
+
     .. versionadded:: 3.2
 
 .. classmethod:: int.from_bytes(bytes, byteorder, *, signed=False)
@@ -558,6 +570,22 @@ class`. In addition, it provides a few more methods:
 
     The *signed* argument indicates whether two's complement is used to
     represent the integer.
+
+    Equivalent to::
+
+        def from_bytes(bytes, byteorder, signed=False):
+            if byteorder == 'little':
+                little_ordered = list(bytes)
+            elif byteorder == 'big':
+                little_ordered = list(reversed(bytes))
+            else:
+                raise ValueError("byteorder must be either 'little' or 'big'")
+
+            n = sum(b << i*8 for i, b in enumerate(little_ordered))
+            if signed and little_ordered and (little_ordered[-1] & 0x80):
+                n -= 1 << 8*len(little_ordered)
+
+            return n
 
     .. versionadded:: 3.2
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -306,6 +306,7 @@ Mitch Chapman
 Matt Chaput
 William Chargin
 Yogesh Chaudhari
+Gautam Chaudhuri
 David Chaum
 Nicolas Chauvat
 Jerry Chen

--- a/Misc/NEWS.d/next/Documentation/2021-08-13-20-17-59.bpo-16580.MZ_iK9.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-08-13-20-17-59.bpo-16580.MZ_iK9.rst
@@ -1,0 +1,2 @@
+Added code equivalents for the :meth:`int.to_bytes` and :meth:`int.from_bytes`
+methods, as well as tests ensuring that these code equivalents are valid.


### PR DESCRIPTION
…27760)

* added code equivs. for to_bytes and from_bytes

Based on woparry's patch[1] from the relevant issue thread[2].

[1]: https://bugs.python.org/file30372/issue16580.patch
[2]: https://bugs.python.org/issue16580

Co-authored-by: Mark Dickinson <dickinsm@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
